### PR TITLE
fix compatibility issue with protobuf

### DIFF
--- a/pyease_grpc/_protocol.py
+++ b/pyease_grpc/_protocol.py
@@ -105,12 +105,21 @@ def message_to_dict(
     float_precision=None,
     use_integers_for_enums=False,
 ) -> dict:
-    return MessageToDict(
-        message,
-        float_precision=float_precision,
-        use_integers_for_enums=use_integers_for_enums,
-        including_default_value_fields=including_defaults,
-    )
+    try:
+        return MessageToDict(
+            message,
+            float_precision=float_precision,
+            use_integers_for_enums=use_integers_for_enums,
+            including_default_value_fields=including_defaults,
+        )
+    except TypeError:
+        return MessageToDict(
+            message,
+            float_precision=float_precision,
+            use_integers_for_enums=use_integers_for_enums,
+            always_print_fields_with_no_presence=including_defaults,
+        )
+
 
 
 def deserialize_message(message_type: Type[Message], data: bytes) -> dict:


### PR DESCRIPTION
fix compatibility issue with protobuf >= 5.26.0
protobuf crash when it handle huge data buffer
it fixed that in its newer version but its not compatible with pyease-grpc <=1.6.1 this will fix this issue